### PR TITLE
use `ActiveSupport.on_load` to hook into Active Job

### DIFF
--- a/lib/active_job/cancel.rb
+++ b/lib/active_job/cancel.rb
@@ -54,4 +54,6 @@ module ActiveJob
   end
 end
 
-ActiveJob::Base.include(ActiveJob::Cancel)
+ActiveSupport.on_load(:active_job) do
+  include(ActiveJob::Cancel)
+end


### PR DESCRIPTION
For avoiding autoloading these constants too soon.
This affect the initialization of Active Job.