### PR TITLE
Added support for the test adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ActiveJob::Cancel
 
-`activejob-cancel` provides cancel method to Active Job. Currently it supports only `Sidekiq`, `Delayed Job` and `resque`.
+`activejob-cancel` provides cancel method to Active Job. Currently it supports only `Sidekiq`, `Delayed Job`, `resque` and the Active Job `TestAdapter`.
 
 [![Build Status](https://travis-ci.org/y-yagi/activejob-cancel.svg?branch=master)](https://travis-ci.org/y-yagi/activejob-cancel)
 [![Gem Version](https://badge.fury.io/rb/activejob-cancel.svg)](http://badge.fury.io/rb/activejob-cancel)

--- a/lib/active_job/cancel.rb
+++ b/lib/active_job/cancel.rb
@@ -1,13 +1,14 @@
 require 'active_support'
 require 'active_job'
 require 'active_job/cancel/queue_adapters'
+require 'active_job/cancel/queue_adapters/test_adapter'
 require 'active_job/cancel/version'
 
 module ActiveJob
   module Cancel
     extend ActiveSupport::Concern
 
-    SUPPORTED_ADAPTERS = %w(Sidekiq DelayedJob Resque).freeze
+    SUPPORTED_ADAPTERS = %w(Sidekiq DelayedJob Resque Test).freeze
 
     def cancel
       if self.class.can_cancel?

--- a/lib/active_job/cancel/queue_adapters.rb
+++ b/lib/active_job/cancel/queue_adapters.rb
@@ -6,6 +6,7 @@ module ActiveJob
       autoload :SidekiqAdapter
       autoload :DelayedJobAdapter
       autoload :ResqueAdapter
+      autoload :TestAdapter
     end
   end
 end

--- a/lib/active_job/cancel/queue_adapters/test_adapter.rb
+++ b/lib/active_job/cancel/queue_adapters/test_adapter.rb
@@ -1,0 +1,48 @@
+require 'active_job'
+
+module ActiveJob
+  module QueueAdapters
+    # Unfortunately we need to monkey patch the Rails TestAdapter class,
+    # because it does not save the job id on the enqueued_jobs array. We rely
+    # on a persisted id to fulfill the canceling of any given job id.
+    class TestAdapter
+      def initialize
+        if Gem::Requirement.new('~> 5.0').satisfied_by? ActiveJob.version
+          require 'active_job/cancel/queue_adapters/test_adapter/rails_5'
+        elsif Gem::Requirement.new('~> 4.2').satisfied_by? ActiveJob.version
+          require 'active_job/cancel/queue_adapters/test_adapter/rails_4'
+        end
+
+        super
+      end
+    end
+  end
+
+  module Cancel
+    module QueueAdapters
+      class TestAdapter
+        def cancel(job_id, queue_name)
+          original_count = adapter.enqueued_jobs.count
+          adapter.enqueued_jobs = reject_job_from_enqueued_jobs(job_id)
+          (original_count == adapter.enqueued_jobs.count) ? false : true
+        end
+
+        def cancel_by(opts, queue_name)
+          unless opts[:provider_job_id]
+            raise ArgumentError, 'Please specify ":provider_job_id"'
+          end
+          self.cancel(opts[:provider_job_id], queue_name)
+        end
+
+        private
+          def adapter
+            ActiveJob::Base.queue_adapter
+          end
+
+          def reject_job_from_enqueued_jobs(job_id)
+            adapter.enqueued_jobs.reject { |job| job[:id] == job_id }
+          end
+      end
+    end
+  end
+end

--- a/lib/active_job/cancel/queue_adapters/test_adapter/rails_4.rb
+++ b/lib/active_job/cancel/queue_adapters/test_adapter/rails_4.rb
@@ -1,0 +1,25 @@
+module ActiveJob
+  module QueueAdapters
+    class TestAdapter
+      alias original_enqueue enqueue
+      alias original_enqueue_at enqueue_at
+
+      def fixup_last_job(job)
+        list = perform_enqueued_jobs ? performed_jobs : enqueued_jobs
+        list.last[:id] = job.job_id
+      end
+
+      def enqueue(job)
+        result = original_enqueue(job)
+        fixup_last_job(job)
+        result
+      end
+
+      def enqueue_at(job, timestamp)
+        result = original_enqueue_at(job, timestamp)
+        fixup_last_job(job)
+        result
+      end
+    end
+  end
+end

--- a/lib/active_job/cancel/queue_adapters/test_adapter/rails_5.rb
+++ b/lib/active_job/cancel/queue_adapters/test_adapter/rails_5.rb
@@ -1,0 +1,14 @@
+module ActiveJob
+  module QueueAdapters
+    class TestAdapter
+      def job_to_hash(job, extras = {})
+        {
+          id: job.job_id,
+          job: job.class,
+          args: job.serialize.fetch('arguments'),
+          queue: job.queue_name
+        }.merge!(extras)
+      end
+    end
+  end
+end

--- a/test/queue_adapters/test_adapter_test.rb
+++ b/test/queue_adapters/test_adapter_test.rb
@@ -1,0 +1,113 @@
+require 'test_helper'
+
+module ActiveJob::Cancel::QueueAdapters
+  class ActiveJob::Cancel::QueueAdapters::TestAdapterTest< Minitest::Test
+    def setup
+      ActiveJob::Base.queue_adapter = :test
+      @hello_job_queue_name = HelloJob.queue_name.call
+      @fail_job_queue_name = FailJob.queue_name.call
+    end
+
+    def teardown
+    end
+
+    def test_cancel_queued_job_with_instance_method
+      assert_equal 0, queue.size
+
+      job = HelloJob.perform_later
+      assert_equal 1, queue.size
+
+      job.cancel
+      assert_equal 0, queue.size
+    ensure
+      queue.clear
+    end
+
+    def test_cancel_queued_job_with_class_method
+      assert_equal 0, queue.size
+
+      job = HelloJob.perform_later
+      assert_equal 1, queue.size
+
+      HelloJob.cancel(job.job_id)
+      assert_equal 0, queue.size
+    ensure
+      queue.clear
+    end
+
+    def test_cancel_scheduled_job_with_instance_method
+      assert_equal 0, queue.size
+
+      job = HelloJob.set(wait: 30.seconds).perform_later
+      assert_equal 1, queue.size
+
+      job.cancel
+      assert_equal 0, queue.size
+    ensure
+      queue.clear
+    end
+
+    def test_cancel_scheduled_job_with_class_method
+      assert_equal 0, queue.size
+
+      job = HelloJob.set(wait: 30.seconds).perform_later
+      assert_equal 1, queue.size
+
+      HelloJob.cancel(job.job_id)
+      assert_equal 0, queue.size
+    ensure
+      queue.map(&:delete)
+    end
+
+    def test_cancel_with_invalid_id
+      job = HelloJob.perform_later
+
+      HelloJob.cancel(job.job_id.to_i + 1)
+      assert_equal 1, queue.size
+    ensure
+      queue.clear
+    end
+
+    def test_cancel_by_with_invalid_parameters
+      assert_raises(ArgumentError) { HelloJob.cancel_by(id: 1) }
+    end
+
+    def test_cancel_queued_job_with_provider_job_id
+      assert_equal 0, queue.size
+
+      HelloJob.perform_later
+      assert_equal 1, queue.size
+
+      HelloJob.cancel_by(provider_job_id: queue.map.first[:id])
+      assert_equal 0, queue.size
+    ensure
+      queue.clear
+    end
+
+    def test_cancel_scheduled_job_with_provider_job_id
+      assert_equal 0, queue.size
+
+      HelloJob.set(wait: 30.seconds).perform_later
+      assert_equal 1, queue.size
+
+      HelloJob.cancel_by(provider_job_id: queue.map.first[:id])
+      assert_equal 0, queue.size
+    ensure
+      queue.map(&:delete)
+    end
+
+    def test_cancel_by_with_invalid_job_id
+      HelloJob.perform_later
+
+      refute HelloJob.cancel_by(provider_job_id: queue.map.first[:id].to_i + 1)
+      assert_equal 1, queue.size
+    ensure
+      queue.clear
+    end
+
+    private
+      def queue
+        ActiveJob::Base.queue_adapter.enqueued_jobs
+      end
+  end
+end


### PR DESCRIPTION
**- What is it good for?**

This update ships a cancel adapter for the [ActiveJob TestAdapter](https://github.com/rails/rails/blob/master/activejob/lib/active_job/queue_adapters/test_adapter.rb). With the help of this it is possible to test a more complex functionality (job, concern, etc) which makes use of canceling logic, without the need to use a real job adapter on the test case. (eg. Sidekiq+Redis etc)

**- What I did**

I added the cancel adapter for the TestAdapter, tests for it and a simple monkey patch for the TestAdpater class itself. Unfortunately the ActiveJob TestAdapter does not persist the job id on its enqueued_jobs array. But this is mandatory to fulfill the canceling, so I patched the `job_to_hash` method to fix this issue.

**- A picture of a cute animal (not mandatory but encouraged)**
![images](https://user-images.githubusercontent.com/2496275/32688389-04e1a1fc-c6d0-11e7-8bea-8eed504bee35.jpeg)
