### PR TITLE
Fix(SidekiqAdapter): fix case when worker's first argument is not a Hash

### DIFF
--- a/lib/active_job/cancel/queue_adapters/sidekiq_adapter.rb
+++ b/lib/active_job/cancel/queue_adapters/sidekiq_adapter.rb
@@ -42,17 +42,17 @@ module ActiveJob
 
           def find_job_from_queue(job_id, queue_name)
             queue = Sidekiq::Queue.new(queue_name)
-            queue.detect { |j| j.args.first['job_id'] == job_id }
+            queue.detect { |j| j.args.first.is_a?(Hash) && j.args.first['job_id'] == job_id }
           end
 
           def find_job_from_scheduled_set(job_id)
             scheduled_set = Sidekiq::ScheduledSet.new
-            scheduled_set.detect { |j| j.args.first['job_id'] == job_id }
+            scheduled_set.detect { |j| j.args.first.is_a?(Hash) && j.args.first['job_id'] == job_id }
           end
 
           def find_job_from_retry_set(job_id)
             scheduled_set = Sidekiq::RetrySet.new
-            scheduled_set.detect { |j| j.args.first['job_id'] == job_id }
+            scheduled_set.detect { |j| j.args.first.is_a?(Hash) && j.args.first['job_id'] == job_id }
           end
       end
     end

--- a/test/support/sidekiq/test_helper.rb
+++ b/test/support/sidekiq/test_helper.rb
@@ -1,5 +1,6 @@
 require 'sidekiq/launcher'
 require 'sidekiq/cli'
+require_relative 'workers/not_an_active_job_worker'
 
 Sidekiq.logger = Logger.new(nil)
 

--- a/test/support/sidekiq/workers/not_an_active_job_worker.rb
+++ b/test/support/sidekiq/workers/not_an_active_job_worker.rb
@@ -1,0 +1,8 @@
+class NotAnActiveJobWorker
+  include Sidekiq::Worker
+
+  def perform
+    # Do nothing
+  end
+
+end


### PR DESCRIPTION
Fix the case when Sidekiq Queue or Schedule Set or Retry Set contain worker that is not created from ActiveJob, thus the first argument of this kind of worker may not always be a Hash and can result in exception.