### PR TITLE
Correctly handling queue name

### DIFF
--- a/lib/active_job/cancel.rb
+++ b/lib/active_job/cancel.rb
@@ -21,7 +21,7 @@ module ActiveJob
     module ClassMethods
       def cancel(job_id)
         if can_cancel?
-          cancel_adapter_class.new.cancel(job_id, self.queue_name)
+          cancel_adapter_class.new.cancel(job_id, self.new.queue_name)
         else
           raise NotImplementedError, 'This queueing backend does not support cancel.'
         end
@@ -29,7 +29,7 @@ module ActiveJob
 
       def cancel_by(opts)
         if can_cancel?
-          cancel_adapter_class.new.cancel_by(opts, self.queue_name)
+          cancel_adapter_class.new.cancel_by(opts, self.new.queue_name)
         else
           raise NotImplementedError, 'This queueing backend does not support cancel_by.'
         end

--- a/test/jobs/default_queue_name.rb
+++ b/test/jobs/default_queue_name.rb
@@ -1,0 +1,5 @@
+class DefaultQueueNameJob < ActiveJob::Base
+  def perform
+    # Do nothing
+  end
+end

--- a/test/queue_adapters/sidekiq_adapter_test.rb
+++ b/test/queue_adapters/sidekiq_adapter_test.rb
@@ -175,6 +175,35 @@ module ActiveJob::Cancel::QueueAdapters
       queue.clear
     end
 
+    def test_cancel_default_queue_name_job_with_class_method
+      default_queue_name = "default"
+      queue = Sidekiq::Queue.new(default_queue_name)
+      assert_equal 0, queue.size
+
+      job = DefaultQueueNameJob.perform_later
+      assert_equal 1, queue.size
+
+      DefaultQueueNameJob.cancel(job.job_id)
+      assert_equal 0, queue.size
+    ensure
+      queue&.clear
+    end
+
+    def test_cancel_by_default_queue_name_job
+      default_queue_name = "default"
+      queue = Sidekiq::Queue.new(default_queue_name)
+      assert_equal 0, queue.size
+
+      job = DefaultQueueNameJob.perform_later
+      assert_equal 1, queue.size
+
+      queue = Sidekiq::Queue.new(default_queue_name)
+      DefaultQueueNameJob.cancel_by(provider_job_id: queue.map.first.jid)
+      assert_equal 0, queue.size
+    ensure
+      queue&.clear
+    end
+
     private
       def scheduled_jobs
         scheduled_set = Sidekiq::ScheduledSet.new

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,5 +6,6 @@ require 'active_job'
 require 'sidekiq'
 require 'jobs/hello_job'
 require 'jobs/fail_job'
+require 'jobs/default_queue_name'
 
 require 'minitest/autorun'


### PR DESCRIPTION
It was expected to get via instance since Rails 6.0.