### PR TITLE
Use same keys and key types as other QueueAdapters do,  to not break ActiveJob test helpers 

### DIFF
--- a/lib/active_job/cancel/queue_adapters/test_adapter/rails.rb
+++ b/lib/active_job/cancel/queue_adapters/test_adapter/rails.rb
@@ -5,6 +5,7 @@ module ActiveJob
         # These values should match up with what other ActiveJob::QueueAdapters publish. At minimum, job_class, job_id...
         # Otherwise, ActiveJob test helpers like assert_enqueued_with will break.
         HashWithIndifferentAccess.new({
+          id: job.job_id,
           job_id: job.job_id,
           job: job.class,
           job_class: job.class.to_s,

--- a/lib/active_job/cancel/queue_adapters/test_adapter/rails.rb
+++ b/lib/active_job/cancel/queue_adapters/test_adapter/rails.rb
@@ -2,13 +2,15 @@ module ActiveJob
   module QueueAdapters
     class TestAdapter
       def job_to_hash(job, extras = {})
-        {
+        # These values should match up with what other ActiveJob::QueueAdapters publish. At minimum, job_class, job_id...
+        # Otherwise, ActiveJob test helpers like assert_enqueued_with will break.
+        HashWithIndifferentAccess.new({
           job_id: job.job_id,
           job: job.class,
           job_class: job.class.to_s,
           args: job.serialize.fetch('arguments'),
           queue: job.queue_name
-        }.merge!(extras)
+        }.merge!(extras))
       end
     end
   end

--- a/lib/active_job/cancel/queue_adapters/test_adapter/rails.rb
+++ b/lib/active_job/cancel/queue_adapters/test_adapter/rails.rb
@@ -3,8 +3,9 @@ module ActiveJob
     class TestAdapter
       def job_to_hash(job, extras = {})
         {
-          id: job.job_id,
+          job_id: job.job_id,
           job: job.class,
+          job_class: job.class.to_s,
           args: job.serialize.fetch('arguments'),
           queue: job.queue_name
         }.merge!(extras)

--- a/lib/active_job/cancel/queue_adapters/test_adapter/rails.rb
+++ b/lib/active_job/cancel/queue_adapters/test_adapter/rails.rb
@@ -1,8 +1,9 @@
 module ActiveJob
   module QueueAdapters
     class TestAdapter
+
       def job_to_hash(job, extras = {})
-        # These values should match up with what other ActiveJob::QueueAdapters publish. At minimum, job_class, job_id...
+        # These values should match up with what other ActiveJob::QueueAdapters publish. At minimum, job_class, job_id, arguments...
         # Otherwise, ActiveJob test helpers like assert_enqueued_with will break.
         HashWithIndifferentAccess.new({
           id: job.job_id,
@@ -10,7 +11,9 @@ module ActiveJob
           job: job.class,
           job_class: job.class.to_s,
           args: job.serialize.fetch('arguments'),
-          queue: job.queue_name
+          arguments: job.serialize.fetch('arguments'),
+          queue: job.queue_name,
+          queue_name: job.queue_name
         }.merge!(extras))
       end
     end

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,30 @@
+## Change description
+
+> Description here
+
+## Type of change
+- [ ] Bug fix (fixes an issue)
+- [ ] New feature (adds functionality)
+
+## Related issues
+
+> Fix [#1]() 
+
+## Checklists
+
+### Development
+
+- [ ] Application changes have been tested thoroughly
+- [ ] Automated tests covering modified code pass
+
+### Security
+
+- [ ] Security impact of change has been considered
+- [ ] Code follows company security practices and guidelines
+
+### Code review 
+
+- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
+- [ ] "Ready for review" label attached and reviewers assigned
+- [ ] Changes have been reviewed by at least one other contributor
+- [ ] Pull request linked to issue as appropriate

--- a/test/queue_adapters/test_adapter_test.rb
+++ b/test/queue_adapters/test_adapter_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+include ActiveJob::TestHelper
 
 module ActiveJob::Cancel::QueueAdapters
   class ActiveJob::Cancel::QueueAdapters::TestAdapterTest< Minitest::Test
@@ -77,7 +78,6 @@ module ActiveJob::Cancel::QueueAdapters
 
       HelloJob.perform_later
       assert_equal 1, queue.size
-
       HelloJob.cancel_by(provider_job_id: queue.map.first[:id])
       assert_equal 0, queue.size
     ensure
@@ -101,6 +101,18 @@ module ActiveJob::Cancel::QueueAdapters
 
       refute HelloJob.cancel_by(provider_job_id: queue.map.first[:id].to_i + 1)
       assert_equal 1, queue.size
+    ensure
+      queue.clear
+    end
+
+    def test_activejob_assert_enqueued_with
+      assert_no_enqueued_jobs
+      HelloJob.perform_later('jeremy')
+      assert_enqueued_jobs 1
+
+      assert_enqueued_with(job: HelloJob) do
+        HelloJob.perform_later
+      end
     ensure
       queue.clear
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ require 'coveralls'
 Coveralls.wear!
 require 'active_job/cancel'
 require 'active_job'
+require 'active_job/test_helper'
 require 'sidekiq'
 require 'jobs/hello_job'
 require 'jobs/fail_job'


### PR DESCRIPTION
```assert_enqueued_with``` expects the queue adapter to support particular fields. This PR adds those expected fields. There's a test for assert_enqueued_with, which was the canary for something being broken.

